### PR TITLE
[IE9] Fix for JavaScript issue that happens when a focus event is triggered

### DIFF
--- a/jquery-visibility.js
+++ b/jquery-visibility.js
@@ -22,7 +22,7 @@
 		    originalEvent = event.originalEvent,
 		    toElement = originalEvent && originalEvent.toElement;
 		// To avoid errors from triggered events for which originalEvent is not available.    
-		if(!originalEvent){
+		if (!originalEvent) {
 			return;
 		}    
 		// If it’s a `{focusin,focusout}` event (IE), `fromElement` and `toElement` should both be `null` or `undefined`;


### PR DESCRIPTION
Checking if `originalEvent` is not `undefined`, to avoid errors from triggered events for which `originalEvent` is `undefined`.

Further Information from http://bugs.jquery.com/ticket/8055

The  Event-object documentation says:

>     Certain native events may have special properties that can be accessed as properties of the event.originalEvent object.

The  trigger() documentation (.focus() is short for .trigger("focus")) says:

>     Although .trigger() simulates an event activation, complete with a synthesized event object, it does not perfectly replicate a naturally-occurring event.

As triggering focus with .focus() isn't a native event, the originalEvent property can't available.

Test Case: http://jsfiddle.net/jitter/nTCXz/
