### PR TITLE
Fix prefix evaluation order

### DIFF
--- a/jquery-visibility.js
+++ b/jquery-visibility.js
@@ -9,7 +9,7 @@
 	    $support = $.support,
 	    $event = $.event;
 
-	while ((property = prefix = prefixes.pop()) != undefined) {
+	while ((prefix = prefixes.shift()) != undefined) {
 		property = (prefix ? prefix + 'H': 'h') + 'idden';
 		if ($support.pageVisibility = typeof document[property] == 'boolean') {
 			eventName = prefix + 'visibilitychange';


### PR DESCRIPTION
In IE10 => eventname = visibilitychange but both document.msHidden and document.hidden exists.
Thus, we need to evaluate the empty prefix before the 'ms' one
